### PR TITLE
Fix missing dependency for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ An interactive Streamlit app that visualizes trends in NATO defense spending alo
    ```bash
    git clone https://github.com/jacobvoss/geopolitical-dashboard.git
    cd geopolitical-dashboard
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the app:
+
+   ```bash
+   streamlit run app.py
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ tornado==6.5
 typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
+plotly==6.2.0


### PR DESCRIPTION
## Summary
- add `plotly` to requirements so `app.py` can run
- finish installation steps in README

## Testing
- `python -m py_compile app.py`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883403cf37483209ca069e7e36221f0